### PR TITLE
Fix possibly mismatching type on difficultyLevel

### DIFF
--- a/assets/common/js/models/GameController.js
+++ b/assets/common/js/models/GameController.js
@@ -51,6 +51,7 @@ GameController.prototype.reset = function() {
  */
 GameController.prototype.start = function(difficultyLevel = 1) {
     this.gameInProgress = true;
+    difficultyLevel = parseInt(difficultyLevel);
 
     /*
      * Fill subdictionary for each difficulty level.


### PR DESCRIPTION
When receiving difficulty level input through the GameController.start function, the string type parameter may be passed from the interface script (Game.js).

Added parseInt function in the start function to fix this issue.

When a bonus word spawns, the type mismatch can cause the level to be "41" instead of 4 + 1 (5).