### PR TITLE
Update the label on the game over screen

### DIFF
--- a/assets/common/js/models/GameController.js
+++ b/assets/common/js/models/GameController.js
@@ -329,7 +329,7 @@ GameController.prototype.getPlayerPerformanceData = function() {
     // This elapsed time format will be correct as long as the duration doesn't exceed a day
     obj["elapsed-time"] = new Date(this.timer.getElapsedTime()).toISOString().slice(11,19);
     obj["score"] = this.player.score;
-    obj["highest-difficulty"] = this.gameDifficulty.difficulty;
+    obj["highest-difficulty"] = this.gameDifficulty.getCurrentLevel();
     obj["player-wpm"] = this.getPlayerWPM().toFixed(2);
     obj["num-backspaces"] = this.player.numBackspaces;
     obj["num-bonus"] = this.player.numBonus;

--- a/game.html
+++ b/game.html
@@ -53,7 +53,7 @@
                         <div id="game-score" class="value"></div>
                     </div>
                     <div class="fieldset">
-                        <div class="label">Highest Difficulty Completed:</div>
+                        <div class="label">Highest Difficulty:</div>
                         <div id="game-highest-difficulty" class="value"></div>
                     </div>
                     <div class="fieldset">


### PR DESCRIPTION
Decided to change the label to "Highest Difficulty" and no longer imply that the player attained or completed any level. It will simply display the difficulty at which the game ended.

Justification: A player is allowed to start the game at any level from the difficulty selector. A player can start the game at Level 9 and end game at Level 9. It would be incorrect to say that the player completed Level 8 in this case. Instead of saying "Highest Difficulty Completed", we will go with "Highest Difficulty" and simply display the level at which the game ended.